### PR TITLE
Bug/start date on new mps

### DIFF
--- a/contracts/FountainV1.sol
+++ b/contracts/FountainV1.sol
@@ -486,12 +486,11 @@ contract FountainV1 {
             latestMoneyPool.start.add(latestMoneyPool.duration),
             latestMoneyPool.duration
         );
-        MoneyPool storage moneyPool = _createMoneyPoolFromId(
+        MoneyPool storage newMoneyPool = _createMoneyPoolFromId(
             moneyPoolId,
             start
         );
-        moneyPools[moneyPoolId] = moneyPool;
-        latestMoneyPoolIds[who] = moneyPoolId;
+        moneyPools[moneyPoolId] = newMoneyPool;
 
         return moneyPoolId;
     }
@@ -625,10 +624,10 @@ contract FountainV1 {
         returns (uint256)
     {
         // Use the old end if the current time is still within the duration.
-        if (oldEnd + duration > now) return oldEnd;
+        if (oldEnd.add(duration) > now) return oldEnd;
         // Otherwise, use the closest multiple of the duration from the old end.
-        uint256 distanceToStart = (now - oldEnd).mod(duration);
-        return now - distanceToStart;
+        uint256 distanceToStart = (now.sub(oldEnd)).mod(duration);
+        return now.sub(distanceToStart);
     }
 
     function _state(uint256 moneyPoolId) private view returns (MoneyPoolState) {


### PR DESCRIPTION
There's currently a functionality bug. This fixes it.

The bug occurs when the time of a sustainment to an address, or the time when an address updates its mp, is greater than the its latest sustained MP's start timestamp + its latest MP's duration

The way the contract was previously written, the start timestamp of the MP that the sustainment or update created would be the latest MP's start date + the latest MP's duration. This doesn't make sense.

Now, a sustainment in this circumstance will be allocated to a MP with the start date as a multiple of the old duration from the old end timestamp. An update in this circumstance will start the start timestamp to the time of the transaction.
