### PR TITLE
Style/clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ contracts/artifacts/
 .env.production.local
 
 node_modules/
+
+# private
+.secret

--- a/.secret
+++ b/.secret
@@ -1,0 +1,1 @@
+key duty side raven divert cricket pride art rural eager lawsuit foot thing decrease aim crack dignity journey nominee amazing split caught muscle drama

--- a/contracts/FountainV1.sol
+++ b/contracts/FountainV1.sol
@@ -536,7 +536,7 @@ contract FountainV1 {
     /// @dev Check to see if the given MoneyPool has started.
     /// @param mp The MoneyPool to check.
     /// @return isStarted The boolean result.
-    function _isMoneyPoolStarted(MoneyPool storage mp)
+    function _hasMoneyPoolStarted(MoneyPool storage mp)
         private
         view
         returns (bool isStarted)
@@ -547,7 +547,7 @@ contract FountainV1 {
     /// @dev Check to see if the given MoneyPool has expired.
     /// @param mp The MoneyPool to check.
     /// @return isExpired The boolean result.
-    function _isMoneyPoolExpired(MoneyPool storage mp)
+    function _hasMoneyPoolExpired(MoneyPool storage mp)
         private
         view
         returns (bool isExpired)
@@ -639,13 +639,10 @@ contract FountainV1 {
         MoneyPool storage moneyPool = moneyPools[moneyPoolId];
         require(moneyPool.exists, "Fountain::state: Invalid MoneyPool");
 
-        if (_isMoneyPoolExpired(moneyPool)) {
+        if (_hasMoneyPoolExpired(moneyPool))
             return MoneyPoolState.Redistributing;
-        }
 
-        if (_isMoneyPoolStarted(moneyPool) && !_isMoneyPoolExpired(moneyPool)) {
-            return MoneyPoolState.Active;
-        }
+        if (_hasMoneyPoolStarted(moneyPool)) return MoneyPoolState.Active;
 
         return MoneyPoolState.Pending;
     }

--- a/contracts/FountainV1.sol
+++ b/contracts/FountainV1.sol
@@ -72,8 +72,6 @@ contract FountainV1 {
         mapping(address => uint256) redistributionTracker;
     }
 
-    enum Pool {REDISTRIBUTION, SUSTAINABILITY}
-
     /// @notice The official record of all MoneyPools ever created
     mapping(uint256 => MoneyPool) public moneyPools;
 

--- a/contracts/FountainV1.sol
+++ b/contracts/FountainV1.sol
@@ -115,6 +115,7 @@ contract FountainV1 {
 
     event SustainMoneyPool(
         uint256 indexed id,
+        address indexed owner,
         address indexed sustainer,
         uint256 amount
     );
@@ -265,7 +266,12 @@ contract FountainV1 {
         _updateTrackedRedistribution(currentMoneyPool);
 
         // Emit events.
-        emit SustainMoneyPool(moneyPoolId, msg.sender, amount);
+        emit SustainMoneyPool(
+            moneyPoolId,
+            currentMoneyPool.owner,
+            msg.sender,
+            amount
+        );
 
         if (wasInactive)
             // Emit an event since since is the first sustainment being made towards this MoneyPool.

--- a/contracts/FountainV1.sol
+++ b/contracts/FountainV1.sol
@@ -413,9 +413,8 @@ contract FountainV1 {
         MoneyPool storage newMoneyPool = moneyPools[moneyPoolCount];
         newMoneyPool.owner = owner;
         newMoneyPool.currentSustainment = 0;
-        newMoneyPool.start = now;
         newMoneyPool.exists = true;
-        newMoneyPool.previousMoneyPoolId = 0;
+        newMoneyPool.previousMoneyPoolId = latestMoneyPoolIds[owner];
 
         latestMoneyPoolIds[owner] = moneyPoolCount;
 
@@ -464,7 +463,11 @@ contract FountainV1 {
 
         if (moneyPoolId != 0) return _createMoneyPoolFromId(moneyPoolId, now);
 
-        return _initMoneyPoolId(owner);
+        moneyPoolId = _initMoneyPoolId(owner);
+        MoneyPool storage moneyPool = moneyPools[moneyPoolId];
+        moneyPool.start = now;
+
+        return moneyPoolId;
     }
 
     /// @dev Only active MoneyPools can be sustained.
@@ -598,18 +601,15 @@ contract FountainV1 {
             "Fountain::createMoneyPoolFromId: Invalid moneyPool"
         );
 
-        moneyPoolCount++;
+        uint256 id = _initMoneyPoolId(currentMoneyPool.owner);
         // Must create structs that have mappings using this approach to avoid
         // the RHS creating a memory-struct that contains a mapping.
         // See https://ethereum.stackexchange.com/a/72310
-        MoneyPool storage moneyPool = moneyPools[moneyPoolCount];
-        moneyPool.owner = currentMoneyPool.owner;
+        MoneyPool storage moneyPool = moneyPools[id];
         moneyPool.sustainabilityTarget = currentMoneyPool.sustainabilityTarget;
-        moneyPool.currentSustainment = 0;
         moneyPool.start = start;
         moneyPool.duration = currentMoneyPool.duration;
         moneyPool.want = currentMoneyPool.want;
-        moneyPool.exists = true;
         moneyPool.previousMoneyPoolId = moneyPoolId;
 
         latestMoneyPoolIds[currentMoneyPool.owner] = moneyPoolCount;

--- a/contracts/FountainV1.sol
+++ b/contracts/FountainV1.sol
@@ -94,13 +94,7 @@ contract FountainV1 {
     // The contract currently only supports sustainments in DAI.
     address public DAI;
 
-    event InitializeMoneyPool(
-        uint256 indexed id,
-        address indexed owner,
-        uint256 indexed sustainabilityTarget,
-        uint256 duration,
-        address want
-    );
+    event InitializeMoneyPool(uint256 indexed id, address indexed owner);
 
     // This even should trigger when an MP's state changes to active.
     event ActivateMoneyPool(
@@ -381,13 +375,7 @@ contract FountainV1 {
         moneyPool.duration = duration;
         moneyPool.want = want;
         if (moneyPool.previousMoneyPoolId == 0)
-            emit InitializeMoneyPool(
-                moneyPoolCount,
-                msg.sender,
-                target,
-                duration,
-                want
-            );
+            emit InitializeMoneyPool(moneyPoolCount, msg.sender);
 
         emit ConfigureMoneyPool(
             moneyPoolCount,

--- a/test-helpers/assertions.js
+++ b/test-helpers/assertions.js
@@ -46,10 +46,7 @@ exports.assertInitializeMoneyPoolEvent = async (
   truffleAssert.eventEmitted(tx, "InitializeMoneyPool", (ev) => {
     return (
       ev.id.toString() === currentCount &&
-      ev.owner === creator &&
-      ev.sustainabilityTarget.toString() === target.toString() &&
-      ev.duration.toString() === duration.toString() &&
-      ev.want === want
+      ev.owner === creator
     )
   }, message);
 };

--- a/test-helpers/assertions.js
+++ b/test-helpers/assertions.js
@@ -93,27 +93,6 @@ exports.assertConfigureMoneyPoolEvent = async (
   }, message);
 };
 
-exports.assertActivateMoneyPoolEvent = async (
-  tx,
-  instance,
-  creator, 
-  target, 
-  duration, 
-  want,
-  message
-) => {
-  const currentCount = (await instance.moneyPoolCount()).toString();
-  truffleAssert.eventEmitted(tx, "ActivateMoneyPool", (ev) => {
-    return (
-      ev.id.toString() === currentCount &&
-      ev.owner === creator &&
-      ev.sustainabilityTarget.toString() === target.toString() &&
-      ev.duration.toString() === duration.toString() &&
-      ev.want === want
-    )
-  }, message);
-};
-
 exports.assertSustainMoneyPoolEvent = async (
   tx,
   instance,

--- a/test-helpers/assertions.js
+++ b/test-helpers/assertions.js
@@ -33,7 +33,7 @@ exports.assertSustainerCount = async (instance, address, count, message) => {
   assert.equal(sustainerCount, count, message);
 };
 
-exports.assertCreateMoneyPoolEvent = async (
+exports.assertInitializeMoneyPoolEvent = async (
   tx,
   instance,
   creator, 
@@ -43,10 +43,10 @@ exports.assertCreateMoneyPoolEvent = async (
   message
 ) => {
   const currentCount = (await instance.moneyPoolCount()).toString();
-  truffleAssert.eventEmitted(tx, "CreateMoneyPool", (ev) => {
+  truffleAssert.eventEmitted(tx, "InitializeMoneyPool", (ev) => {
     return (
       ev.id.toString() === currentCount &&
-      ev.by === creator &&
+      ev.owner === creator &&
       ev.sustainabilityTarget.toString() === target.toString() &&
       ev.duration.toString() === duration.toString() &&
       ev.want === want
@@ -54,7 +54,7 @@ exports.assertCreateMoneyPoolEvent = async (
   }, message);
 };
 
-exports.assertUpdateMoneyPoolEvent = async (
+exports.assertActivateMoneyPoolEvent = async (
   tx,
   instance,
   creator, 
@@ -64,10 +64,52 @@ exports.assertUpdateMoneyPoolEvent = async (
   message
 ) => {
   const currentCount = (await instance.moneyPoolCount()).toString();
-  truffleAssert.eventEmitted(tx, "UpdateMoneyPool", (ev) => {
+  truffleAssert.eventEmitted(tx, "ActivateMoneyPool", (ev) => {
     return (
       ev.id.toString() === currentCount &&
-      ev.by === creator &&
+      ev.owner === creator &&
+      ev.sustainabilityTarget.toString() === target.toString() &&
+      ev.duration.toString() === duration.toString() &&
+      ev.want === want
+    )
+  }, message);
+};
+
+exports.assertConfigureMoneyPoolEvent = async (
+  tx,
+  instance,
+  creator, 
+  target, 
+  duration, 
+  want,
+  message
+) => {
+  const currentCount = (await instance.moneyPoolCount()).toString();
+  truffleAssert.eventEmitted(tx, "ConfigureMoneyPool", (ev) => {
+    return (
+      ev.id.toString() === currentCount &&
+      ev.owner === creator &&
+      ev.sustainabilityTarget.toString() === target.toString() &&
+      ev.duration.toString() === duration.toString() &&
+      ev.want === want
+    )
+  }, message);
+};
+
+exports.assertActivateMoneyPoolEvent = async (
+  tx,
+  instance,
+  creator, 
+  target, 
+  duration, 
+  want,
+  message
+) => {
+  const currentCount = (await instance.moneyPoolCount()).toString();
+  truffleAssert.eventEmitted(tx, "ActivateMoneyPool", (ev) => {
+    return (
+      ev.id.toString() === currentCount &&
+      ev.owner === creator &&
       ev.sustainabilityTarget.toString() === target.toString() &&
       ev.duration.toString() === duration.toString() &&
       ev.want === want

--- a/test-helpers/assertions.js
+++ b/test-helpers/assertions.js
@@ -117,6 +117,7 @@ exports.assertActivateMoneyPoolEvent = async (
 exports.assertSustainMoneyPoolEvent = async (
   tx,
   instance,
+  creator,
   sustainer,
   amount,
   message
@@ -125,6 +126,7 @@ exports.assertSustainMoneyPoolEvent = async (
   truffleAssert.eventEmitted(tx, "SustainMoneyPool", (ev) => {
     return (
       ev.id.toString() === currentCount &&
+      ev.owner === creator &&
       ev.sustainer === sustainer &&
       ev.amount.toString() === amount.toString()
     )

--- a/test/FountainV1.test.js
+++ b/test/FountainV1.test.js
@@ -87,6 +87,15 @@ contract("Fountain", ([owner, creator, sustainer]) => {
         erc20Mock.address,
         "Invalid InitializeMoneyPool event"
       );
+      await assertConfigureMoneyPoolEvent(
+        result, 
+        fountain, 
+        creator, 
+        target, 
+        duration, 
+        erc20Mock.address,
+        "Invalid ConfigureMoneyPool event"
+      );
     });
   });
 

--- a/test/FountainV1.test.js
+++ b/test/FountainV1.test.js
@@ -215,6 +215,7 @@ contract("Fountain", ([owner, creator, sustainer]) => {
         await assertSustainMoneyPoolEvent(
           result, 
           fountain, 
+          creator,
           sustainer, 
           scenario.amount,
           "Invalid SustainMoneyPool event"


### PR DESCRIPTION
This PR includes style, api, and event schema changes, in preparation for a web3 frontend and adding dependencies to MPs.

It clarifies and simplifies the API a bit, and reduces it's overall size.

- rename `who` property in the MoneyPool to `owner`. Clarity.
- change both `createMoneyPool` and `updateMoneyPool` into one `configureMoneyPool` external function.
- Log a `InitializeMoneyPool` event when a new owner makes a MoneyPool. This will allow us to show a list of all addresses that own a Money Pool.
- Log a `ConfigureMoneyPool` event when a MoneyPool gets initialized or reconfigured. This will allow us to show a list of each time a MoneyPool's configurations were changed by the owner.
- Log a `ActivateMoneyPool` event when a MP's status changes to ACTIVE (when a MP's first sustainment is made). This will allow us to show a list of all MoneyPools an owner has had over time.
- Add the owner to the `SustainMoneyPool` event. This will allow us to show a list of all sustainments made to a MoneyPool, to an owner, and by a sustainer.
- Log separate events for collection from sustainment pool and redistribution pool.
- Remove Pool enum.

Tests pass.

